### PR TITLE
Add `Input`, `labelcolor` and `iconcolor` keywords for sitemap

### DIFF
--- a/openhab.nanorc
+++ b/openhab.nanorc
@@ -31,7 +31,7 @@ syntax "sitemaps" ".sitemap"
 # Keywords
 color magenta "\<(Switch|Selection|Slider|List|Setpoint|Video|Chart|Webview|Colorpicker|Default|Mapview|Input)\>"
 color magenta "\<(Text|Group|Image|Frame)\>"
-color magenta "\<(name|label|item|period|refresh|icon|mappings|minValue|maxValue|step|switchsupport|url|height|refresh|visibility|valuecolor|inputHint)\>"
+color magenta "\<(name|label|item|period|refresh|icon|mappings|minValue|maxValue|step|switchsupport|url|height|refresh|visibility|labelcolor|valuecolor|iconcolor|inputHint)\>"
 
 # Commands
 color green "\<(ON|OFF|on|off)\>"

--- a/openhab.nanorc
+++ b/openhab.nanorc
@@ -29,9 +29,9 @@ color brightgreen start="/\*\*" end="\*/"
 syntax "sitemaps" ".sitemap"
 
 # Keywords
-color magenta "\<(Switch|Selection|Slider|List|Setpoint|Video|Chart|Webview|Colorpicker|Default|Mapview)\>"
+color magenta "\<(Switch|Selection|Slider|List|Setpoint|Video|Chart|Webview|Colorpicker|Default|Mapview|Input)\>"
 color magenta "\<(Text|Group|Image|Frame)\>"
-color magenta "\<(name|label|item|period|refresh|icon|mappings|minValue|maxValue|step|switchsupport|url|height|refresh|visibility|valuecolor)\>"
+color magenta "\<(name|label|item|period|refresh|icon|mappings|minValue|maxValue|step|switchsupport|url|height|refresh|visibility|valuecolor|inputHint)\>"
 
 # Commands
 color green "\<(ON|OFF|on|off)\>"


### PR DESCRIPTION
See https://next.openhab.org/docs/ui/sitemaps.html#element-type-input and:
- openhab/openhab-core#3398
- openhab/openhab-core#3418

Also add `labelcolor` and `iconcolor` - see https://next.openhab.org/docs/ui/sitemaps.html#label-value-and-icon-colors