### PR TITLE
Add `Buttongrid` keyword for sitemap

### DIFF
--- a/openhab.nanorc
+++ b/openhab.nanorc
@@ -29,9 +29,9 @@ color brightgreen start="/\*\*" end="\*/"
 syntax "sitemaps" ".sitemap"
 
 # Keywords
-color magenta "\<(Switch|Selection|Slider|List|Setpoint|Video|Chart|Webview|Colorpicker|Default|Mapview|Input)\>"
+color magenta "\<(Switch|Selection|Slider|List|Setpoint|Video|Chart|Webview|Colorpicker|Default|Mapview|Input|Buttongrid)\>"
 color magenta "\<(Text|Group|Image|Frame)\>"
-color magenta "\<(name|label|item|period|refresh|icon|mappings|minValue|maxValue|step|switchsupport|url|height|refresh|visibility|labelcolor|valuecolor|iconcolor|inputHint)\>"
+color magenta "\<(name|label|item|period|refresh|icon|mappings|minValue|maxValue|step|switchsupport|url|height|refresh|visibility|labelcolor|valuecolor|iconcolor|inputHint|staticIcon|buttons)\>"
 
 # Commands
 color green "\<(ON|OFF|on|off)\>"


### PR DESCRIPTION
See https://www.openhab.org/docs/ui/sitemaps.html#element-type-buttongrid and openhab/openhab-core#3810.